### PR TITLE
fix updating of cookie expiry

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -37,5 +37,18 @@ Example Usage:
         fmt.Fprintln(w, "ok")
     }
 
+Updating Cookie and MongoDB Expiry Times
+
+    if you need your cookies to be rolling and update with every access and
+    not just modifications you can call:
+
+    // Get a session.
+    session, err := store.GetAndUpdateAccessTime(r, w, "session-key")
+
+    instead of
+
+    // Get a session.
+    session, err := store.Get(r, "session-key")
+
 */
 package mongostore

--- a/mongostore.go
+++ b/mongostore.go
@@ -31,29 +31,26 @@ type Session struct {
 
 // MongoStore struct contains options and variables to interact with session settings
 type MongoStore struct {
-	Codecs         []securecookie.Codec
-	Options        *sessions.Options
-	Token          TokenGetSeter
-	autoUpdateTime bool
-	collection     string
-	dbSession      *mgo.Session
+	Codecs     []securecookie.Codec
+	Options    *sessions.Options
+	Token      TokenGetSeter
+	collection string
+	dbSession  *mgo.Session
 }
 
 // New returns a new MongoStore.
 // Set ensureTTL to true let the database auto-remove expired object by maxAge.
 // This is using *mgo.Session instead of *.mgo.Collection because if the database goes offline and then
 // comes back onlne we will need the session to refresh the database connection.
-// autoUpdateAccessTime - When true the sessions access time will be updated upon every access, even read operations.
 // If false it will only update upon save, or manual intervention within the clients code.
-func New(s *mgo.Session, collectionName string, options *sessions.Options, ensureTTL bool, autoUpdateAccessTime bool, keyPairs ...[]byte) *MongoStore {
+func New(s *mgo.Session, collectionName string, options *sessions.Options, ensureTTL bool, keyPairs ...[]byte) *MongoStore {
 
 	store := &MongoStore{
-		Codecs:         securecookie.CodecsFromPairs(keyPairs...),
-		Options:        options,
-		Token:          &CookieToken{},
-		autoUpdateTime: autoUpdateAccessTime,
-		dbSession:      s,
-		collection:     collectionName,
+		Codecs:     securecookie.CodecsFromPairs(keyPairs...),
+		Options:    options,
+		Token:      &CookieToken{},
+		dbSession:  s,
+		collection: collectionName,
 	}
 
 	dbSess := s.Copy()
@@ -73,7 +70,31 @@ func New(s *mgo.Session, collectionName string, options *sessions.Options, ensur
 	return store
 }
 
-// Get return a session for the given session name or creates a new one and return it.
+// GetAndUpdateAccessTime returns a session for the given session name or creates a new one and if exists updates it's lastAccessed time
+func (m *MongoStore) GetAndUpdateAccessTime(r *http.Request, w http.ResponseWriter, name string) (*sessions.Session, error) {
+
+	var err error
+	var session *sessions.Session
+
+	if session, err = m.Get(r, name); err != nil {
+		return nil, err
+	}
+
+	if session.IsNew {
+		return session, err
+	}
+
+	// ensure access time is update to time.Now().UTC() in upsert
+	delete(session.Values, lastAccessedField)
+
+	if err = m.Save(r, w, session); err != nil {
+		return nil, err
+	}
+
+	return session, err
+}
+
+// Get returns a session for the given session name or creates a new one and return it.
 func (m *MongoStore) Get(r *http.Request, name string) (*sessions.Session, error) {
 	return sessions.GetRegistry(r).Get(m, name)
 }
@@ -162,16 +183,6 @@ func (m *MongoStore) load(session *sessions.Session) error {
 
 	if err = c.FindId(bson.ObjectIdHex(session.ID)).One(&s); err != nil {
 		return err
-	}
-
-	if m.autoUpdateTime {
-
-		accessed := time.Now().UTC()
-		s.LastAccessed = &accessed
-
-		if err = c.UpdateId(s.ID, s); err != nil {
-			return err
-		}
 	}
 
 	if err = securecookie.DecodeMulti(session.Name(), s.Data, &session.Values, m.Codecs...); err != nil {

--- a/mongostore_test.go
+++ b/mongostore_test.go
@@ -71,13 +71,13 @@ func (ms *MySuite) TestMongoStoreCoreFuntionality(c *C) {
 		MaxAge: 3600,
 		Path:   "/",
 	}
-	store := mongostore.New(dbSession, "sessions", options, true, true, []byte(mySecretKeyString))
+	store := mongostore.New(dbSession, "sessions", options, true, []byte(mySecretKeyString))
 
 	r, _ := http.NewRequest("GET", url, nil)
 	res := httptest.NewRecorder()
 
 	// Get a session.
-	session, err := store.Get(r, mySessionKey)
+	session, err := store.GetAndUpdateAccessTime(r, res, mySessionKey)
 	c.Assert(err, IsNil)
 
 	// Attempt to retrieve flash messages


### PR DESCRIPTION
remove autoupdate access time option, as it was not working
add GetAndUpdateAccessTime function to allow for updating of the cookie and database expiry times

for issue #13
